### PR TITLE
Set Units of time axis in kymograph image properties

### DIFF
--- a/src/main/java/sc/fiji/kymographBuilder/KymographCreator.java
+++ b/src/main/java/sc/fiji/kymographBuilder/KymographCreator.java
@@ -244,8 +244,9 @@ public class KymographCreator {
 		CalibratedAxis positionAxis = this.dataset.axis(this.dataset.dimensionIndex(Axes.X)).copy();
 		this.projectedKymograph.setAxis(positionAxis, 0);
 
-		CalibratedAxis timAxis = new DefaultLinearAxis(Axes.Y, this.dataset.axis(this.dataset
-			.dimensionIndex(Axes.TIME)).calibratedValue(1));
+		CalibratedAxis timAxis = new DefaultLinearAxis(Axes.Y,
+			this.dataset.axis(this.dataset.dimensionIndex(Axes.TIME)).unit(),
+			this.dataset.axis(this.dataset.dimensionIndex(Axes.TIME)).calibratedValue(1));
 		this.projectedKymograph.setAxis(timAxis, 1);
 
 		// I don't understand everything here (mostly the type stuff) but it


### PR DESCRIPTION
This commit adds one line of code that sets units for the Y axis in `Image>Properties...` of the generated kymograph. The advantage is that now, the kymograph indicates *i.e* `30 µm x 120 sec` instead of `30 µm x 120 µm`.